### PR TITLE
Better fragment names

### DIFF
--- a/klab/bio/fragments/generate_fragments.py
+++ b/klab/bio/fragments/generate_fragments.py
@@ -478,7 +478,7 @@ def setup_jobs(outpath, options, input_files):
         assert(not(fasta_file_contents.get(input_file)))
         if any(fnmatch(input_file, x) for x in pdb_file_wildcards):
             pdb = PDB.from_filepath(input_file, strict=True)
-            pdb.pdb_id = os.path.basename(input_file).split('.')[0]            
+            pdb.pdb_id = '.'.join(os.path.basename(input_file).split('.')[:-1])
             if pdb.pdb_id.startswith('pdb') and len(pdb.pdb_id) >= 7:
                 # Hack to rename FASTA identifiers for pdb*.ent files which are present in mirrors of the PDB
                 pdb.pdb_id = pdb.pdb_id.replace('pdb', '')    
@@ -589,7 +589,7 @@ def parse_FASTA_files(options, fasta_file_contents):
                         raise Exception("The chain identifier in the description line ('%s') of record %d of %s is the wrong length. It must be exactky one character long." % (line, record_count, fasta_file_name))
 
                     # Note: We store the PDB ID as lower-case so that the user does not have to worry about case-sensitivity here (we convert the user's PDB ID argument to lower-case as well)
-                    key = (tokens[0][0:4].lower(), tokens[1], fasta_file_name)
+                    key = (tokens[0].lower(), tokens[1], fasta_file_name)
                     sub_key = (key[0], key[1]) # this is the part of the key that we expect to be unique (the actual key)
                     key_location[key] = fasta_file_name
                     if sub_key in unique_keys:

--- a/klab/bio/fragments/make_fragments_QB3_cluster.pl
+++ b/klab/bio/fragments/make_fragments_QB3_cluster.pl
@@ -316,8 +316,8 @@ if ( !defined( $opts{id} ) ) {
         $options{id} = 't001_';
     }
 
-    $options{chain} = substr( $options{id}, 4, 1 );
-    $options{id}    = substr( $options{id}, 0, 4 );
+    $options{chain} = substr( $options{id}, -1 );
+    $options{id}    = substr( $options{id}, 0, -1 );
     print_debug("ID: $options{id} CHAIN: $options{chain}");
 }
 else {
@@ -325,16 +325,12 @@ else {
 
     print_debug("id specified by user: $opts{id}");
 
-    if ( length( $opts{id} ) != 5 ) {
-        die("The id you specify must be 5 characters long.\n");
-    }
-
     if ( $opts{id} =~ /\W+/ ) {
         die("Only alphanumeric characters and _ area allowed in the id.\n");
     }
 
-    $options{id}    = substr( $opts{id}, 0, 4 );
-    $options{chain} = substr( $opts{id}, 4, 1 );
+    $options{id}    = substr( $opts{id}, 0, -1 );
+    $options{chain} = substr( $opts{id}, -1 );
 
     if ( -s "$options{id}$options{chain}.fasta" ) {
         my @diff = `diff $options{id}$options{chain}.fasta $options{fastafile}`;

--- a/klab/rosetta/input_files.py
+++ b/klab/rosetta/input_files.py
@@ -313,8 +313,10 @@ class Resfile (object):
                     new_residues = []
 
                     if range_start and range_end:
-                        range_start_num = int([x for x in range_start if x.isdigit()]) + 1
-                        range_end_num = int([x for x in range_end if x.isdigit()])
+                        range_start_num = int(''.join([x for x in
+                            range_start if x.isdigit()])) + 1
+                        range_end_num = int(''.join([x for x in
+                            range_end if x.isdigit()]))
 
                         new_residues.append( range_start )
                         if range_start_num < range_end_num:


### PR DESCRIPTION
Klab, and the generate_fragments perl script, only look at the first four letters of the input PDB name, assuming it is a PDB identifier. When generating fragments for designs, this can be a burden, so I changed it to take the whole basename of the PDB file and use that as its identifier.